### PR TITLE
BUG,CI: Fix strdup declaration on Cygwin and add Cygwin CI.

### DIFF
--- a/.github/workflows/cygwin-ci.yml
+++ b/.github/workflows/cygwin-ci.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Build C++11
         shell: "C:/tools/Cygwin/bin/bash.exe -o igncr -eo pipefail {0}"
-        run: cmake --build . -j 2
+        run: cmake --build . -j 1
 
       - name: Python tests C++11
         shell: "C:/tools/Cygwin/bin/bash.exe -o igncr -eo pipefail {0}"

--- a/.github/workflows/cygwin-ci.yml
+++ b/.github/workflows/cygwin-ci.yml
@@ -1,6 +1,6 @@
 # To enable this workflow on a fork, comment out:
 #
-# if: github.repository == 'numpy/numpy'
+# if: github.repository == 'pybind/pybind11'
 name: Test on Cygwin
 on:
   workflow_dispatch:
@@ -31,7 +31,7 @@ env:
 jobs:
   cygwin_build_test:
     runs-on: windows-latest
-    if: "github.repository == 'numpy/numpy'"
+    # if: "github.repository == 'pybind/pybind11'"
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:

--- a/.github/workflows/cygwin-ci.yml
+++ b/.github/workflows/cygwin-ci.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Tell Cygwin's git about this repository.
         run: |
           dash -c "which git; /usr/bin/git config --system --add safe.directory /cygdrive/d/a/pybind11/pybind11"
-          dash -c "/usr/bin/git config --system --add safe.directory `pwd`"
+          bash -c "/usr/bin/git config --system --add safe.directory $(pwd)"
 
       # First build - C++11 mode and inplace
       # More-or-less randomly adding -DPYBIND11_SIMPLE_GIL_MANAGEMENT=ON here.

--- a/.github/workflows/cygwin-ci.yml
+++ b/.github/workflows/cygwin-ci.yml
@@ -46,7 +46,7 @@ jobs:
           packages: >-
             python39=3.9.16-1 python39-devel=3.9.16-1 python39-pip python-pip-wheel
             python-setuptools-wheel liblapack-devel liblapack0 gcc-fortran
-            gcc-g++ git dash cmake ninja make libboost-devel 
+            gcc-g++ git dash cmake ninja make libboost-devel eigen3
             python39-numpy python39-pytest
       - name: Set Windows PATH
         uses: egor-tensin/cleanup-path@f04bc953e6823bf491cc0bdcff959c630db1b458 # v4.0.1
@@ -67,7 +67,7 @@ jobs:
         shell: "C:/tools/Cygwin/bin/bash.exe -o igncr -eo pipefail {0}"
         run: >
           cmake -S . -B .
-          -DPYBIND11_WERROR=ON
+          -DPYBIND11_WERROR=OFF
           -DPYBIND11_SIMPLE_GIL_MANAGEMENT=ON
           -DDOWNLOAD_CATCH=ON
           -DDOWNLOAD_EIGEN=ON

--- a/.github/workflows/cygwin-ci.yml
+++ b/.github/workflows/cygwin-ci.yml
@@ -24,6 +24,7 @@ env:
   PYTEST_TIMEOUT: 300
   # For cmake:
   VERBOSE: 1
+  # For Cygwin
   CYGWIN_NOWINPATH: 1
   SHELLOPTS: igncr
   CHERE_INVOKING: 1
@@ -45,7 +46,7 @@ jobs:
           packages: >-
             python39=3.9.16-1 python39-devel=3.9.16-1 python39-pip python-pip-wheel
             python-setuptools-wheel liblapack-devel liblapack0 gcc-fortran
-            gcc-g++ git dash cmake ninja libboost-devel 
+            gcc-g++ git dash cmake ninja make libboost-devel 
             python39-numpy python39-pytest
       - name: Set Windows PATH
         uses: egor-tensin/cleanup-path@f04bc953e6823bf491cc0bdcff959c630db1b458 # v4.0.1

--- a/.github/workflows/cygwin-ci.yml
+++ b/.github/workflows/cygwin-ci.yml
@@ -1,0 +1,96 @@
+# To enable this workflow on a fork, comment out:
+#
+# if: github.repository == 'numpy/numpy'
+name: Test on Cygwin
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - master
+      - stable
+      - v*
+
+permissions: read-all
+
+concurrency:
+  group: test-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  PIP_BREAK_SYSTEM_PACKAGES: 1
+  PIP_ONLY_BINARY: numpy
+  FORCE_COLOR: 3
+  PYTEST_TIMEOUT: 300
+  # For cmake:
+  VERBOSE: 1
+  CYGWIN_NOWINPATH: 1
+  SHELLOPTS: igncr
+  CHERE_INVOKING: 1
+
+jobs:
+  cygwin_build_test:
+    runs-on: windows-latest
+    if: "github.repository == 'numpy/numpy'"
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          submodules: recursive
+          fetch-depth: 0
+      - name: Install Cygwin
+        uses: egor-tensin/setup-cygwin@d2c752bab416d4b0662591bd366fc2686297c82d   #v4
+        with:
+          platform: x86_64
+          install-dir: 'C:\tools\cygwin'
+          packages: >-
+            python39=3.9.16-1 python39-devel=3.9.16-1 python39-pip python-pip-wheel
+            python-setuptools-wheel liblapack-devel liblapack0 gcc-fortran
+            gcc-g++ git dash cmake ninja libboost-devel 
+            python39-numpy python39-pytest
+      - name: Set Windows PATH
+        uses: egor-tensin/cleanup-path@f04bc953e6823bf491cc0bdcff959c630db1b458 # v4.0.1
+        with:
+          dirs: 'C:\tools\cygwin\bin;C:\tools\cygwin\lib\lapack'
+      - name: Verify that bash is Cygwin bash
+        run: |
+          command bash
+          bash -c "uname -svrmo"
+      - name: Tell Cygwin's git about this repository.
+        run: |
+          dash -c "which git; /usr/bin/git config --system --add safe.directory /cygdrive/d/a/pybind11/pybind11"
+          dash -c "/usr/bin/git config --system --add safe.directory `pwd`"
+
+      # First build - C++11 mode and inplace
+      # More-or-less randomly adding -DPYBIND11_SIMPLE_GIL_MANAGEMENT=ON here.
+      - name: Configure C++11
+        shell: "C:/tools/Cygwin/bin/bash.exe -o igncr -eo pipefail {0}"
+        run: >
+          cmake -S . -B .
+          -DPYBIND11_WERROR=ON
+          -DPYBIND11_SIMPLE_GIL_MANAGEMENT=ON
+          -DDOWNLOAD_CATCH=ON
+          -DDOWNLOAD_EIGEN=ON
+          -DCMAKE_CXX_STANDARD=11
+          ${{ matrix.args }}
+
+      - name: Build C++11
+        shell: "C:/tools/Cygwin/bin/bash.exe -o igncr -eo pipefail {0}"
+        run: cmake --build . -j 2
+
+      - name: Python tests C++11
+        shell: "C:/tools/Cygwin/bin/bash.exe -o igncr -eo pipefail {0}"
+        run: cmake --build . --target pytest -j 2
+
+      - name: C++11 tests
+        # TODO: Figure out how to load the DLL on Python 3.8+
+        if: "!(runner.os == 'Windows' && (matrix.python == 3.8 || matrix.python == 3.9 || matrix.python == '3.10' || matrix.python == '3.11' || matrix.python == 'pypy-3.8'))"
+        shell: "C:/tools/Cygwin/bin/bash.exe -o igncr -eo pipefail {0}"
+        run: cmake --build .  --target cpptest -j 2
+
+      - name: Interface test C++11
+        shell: "C:/tools/Cygwin/bin/bash.exe -o igncr -eo pipefail {0}"
+        run: cmake --build . --target test_cmake_build
+
+      - name: Clean directory
+        shell: "C:/tools/Cygwin/bin/bash.exe -o igncr -eo pipefail {0}"
+        run: git clean -fdx

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include "pyconfig.h"
 #include "detail/class.h"
 #include "detail/init.h"
 #include "attr.h"


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->
Attempts to fix pybind/pybind11#4999

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst
- Include pyconfig.h in pybind11.h so system headers don't break python.
```

<!-- If the upgrade guide needs updating, note that here too -->
